### PR TITLE
Kernel console, print and utilities

### DIFF
--- a/makefile
+++ b/makefile
@@ -36,6 +36,9 @@ build/kernel/kmalloc.o: build src/kernel/kmalloc.asm
 build/kernel/console.o: build src/kernel/console.c
 	$(CC) -c src/kernel/console.c -o build/kernel/console.o
 
+build/kernel/math.o: build src/kernel/math.c
+	$(CC) -c src/kernel/math.c -o build/kernel/math.o
+
 build/kernel/memory.o: build src/kernel/memory.c
 	$(CC) -c src/kernel/memory.c -o build/kernel/memory.o
 
@@ -43,7 +46,7 @@ build/kernel/entry.o: build src/kernel/entry.c
 	$(CC) -c src/kernel/entry.c -o build/kernel/entry.o
 
 # Compile the kernel to a flat binary
-build/kernel/kernel.bin: build src/link/kernel.ld build/kernel/entry.o build/kernel/kmalloc.o build/kernel/console.o build/kernel/memory.o
+build/kernel/kernel.bin: build src/link/kernel.ld build/kernel/entry.o build/kernel/kmalloc.o build/kernel/console.o build/kernel/memory.o build/kernel/math.o
 	$(LD) -T src/link/kernel.ld -o build/kernel/kernel.o
 	$(OC) --only-section=.text --only-section=.data build/kernel/kernel.o build/kernel/kernel.bin
 

--- a/makefile
+++ b/makefile
@@ -33,11 +33,17 @@ build/boot/start.bin: build src/boot/start.asm src/link/start.ld build/boot/load
 build/kernel/kmalloc.o: build src/kernel/kmalloc.asm
 	$(AS) src/kernel/kmalloc.asm -o build/kernel/kmalloc.o
 
+build/kernel/console.o: build src/kernel/console.c
+	$(CC) -c src/kernel/console.c -o build/kernel/console.o
+
+build/kernel/memory.o: build src/kernel/memory.c
+	$(CC) -c src/kernel/memory.c -o build/kernel/memory.o
+
 build/kernel/entry.o: build src/kernel/entry.c
 	$(CC) -c src/kernel/entry.c -o build/kernel/entry.o
 
 # Compile the kernel to a flat binary
-build/kernel/kernel.bin: build src/link/kernel.ld build/kernel/entry.o build/kernel/kmalloc.o
+build/kernel/kernel.bin: build src/link/kernel.ld build/kernel/entry.o build/kernel/kmalloc.o build/kernel/console.o build/kernel/memory.o
 	$(LD) -T src/link/kernel.ld -o build/kernel/kernel.o
 	$(OC) --only-section=.text --only-section=.data build/kernel/kernel.o build/kernel/kernel.bin
 

--- a/src/kernel/ansi.h
+++ b/src/kernel/ansi.h
@@ -1,0 +1,13 @@
+
+// C0 codes
+#define ANSI_BELL            0x07 /* Makes an audible noise. */
+#define ANSI_BACKSPACE       0x08 /* Moves cursor one character back */
+#define ANSI_TAB             0x09 /* Moves cursor forward to the next tab stop */
+#define ANSI_LINE_FEED       0x0A /* Moves cursor to the next line */
+#define ANSI_CARRIAGE_RETURN 0x0D /* Moves cursor to column on the current line */
+#define ANSI_ESCAPE          0x1B /* Starts all the escape sequences */
+
+// Check if the byte after a ANSI_ESCAPE is a valid C1 code
+#define ANSI_IS_VALID_CODE(x) (((x) >= 0x40) && ((x) <= 0x5F))
+
+// C1 codes

--- a/src/kernel/ansi.h
+++ b/src/kernel/ansi.h
@@ -49,18 +49,18 @@
 #define ANSI_SGR_INVERT_RESET      27  /* Un-swaps background and foreground colors */
 #define ANSI_SGR_FG_COLOR_BEGIN    30  /* First foreground color code */
 #define ANSI_SGR_FG_COLOR_END      37  /* Last foreground color code */
-//#define ANSI_SGR_FG_COLOR_EXTENDED 38  /* Marks the start of extended foreground color code */
+#define ANSI_SGR_FG_COLOR_EXTENDED 38  /* TODO Marks the start of extended foreground color code */
 #define ANSI_SGR_FG_COLOR_RESET    39  /* Reset foreground color to the default value */
 #define ANSI_SGR_FG_BOLD_BEGIN     90  /* Marks the start of intensified foreground color code */
 #define ANSI_SGR_FG_BOLD_END       97  /* Last intensified foreground color code */
 #define ANSI_SGR_BG_COLOR_BEGIN    40  /* First background color code */
 #define ANSI_SGR_BG_COLOR_END      47  /* Last background color code */
-//#define ANSI_SGR_BG_COLOR_EXTENDED 48  /* Marks the start of extended background color code */
+#define ANSI_SGR_BG_COLOR_EXTENDED 48  /* TODO Marks the start of extended background color code */
 #define ANSI_SGR_BG_COLOR_RESET    49  /* Reset background color to the default value */
 #define ANSI_SGR_BG_BOLD_BEGIN     100 /* Marks the start of intensified background color code */
 #define ANSI_SGR_BG_BOLD_END       107 /* Last intensified background color code */
-//#define ANSI_SGR_COLOR_PALLET      2   /* follows the *_EXTENDED colors, marks the start of pallet color */
-//#define ANSI_SGR_COLOR_RGB         5   /* follows the *_EXTENDED colors, marks the start of RGB color */
+#define ANSI_SGR_COLOR_PALLET      2   /* follows the *_EXTENDED colors, marks the start of pallet color */
+#define ANSI_SGR_COLOR_RGB         5   /* follows the *_EXTENDED colors, marks the start of RGB color */
 
 // Erase modes (ANSI_CSI_ED, ANSI_CSI_EL)
 #define ANSI_ERASE_AFTER  0 /* Clear from cursor to the end of object */

--- a/src/kernel/ansi.h
+++ b/src/kernel/ansi.h
@@ -5,9 +5,62 @@
 #define ANSI_TAB             0x09 /* Moves cursor forward to the next tab stop */
 #define ANSI_LINE_FEED       0x0A /* Moves cursor to the next line */
 #define ANSI_CARRIAGE_RETURN 0x0D /* Moves cursor to column on the current line */
-#define ANSI_ESCAPE          0x1B /* Starts all the escape sequences */
+#define ANSI_ESCAPE          0x1B /* Starts all the escape sequences (C1 codes) */
+#define ANSI_ESC_DCS         ((char) 0x90) /* Equivalent to ANSI_ESCAPE + ANSI_DCS */
+#define ANSI_ESC_CSI         ((char) 0x9B) /* Equivalent to ANSI_ESCAPE + ANSI_CSI */
+#define ANSI_ESC_OCS         ((char) 0x9D) /* Equivalent to ANSI_ESCAPE + ANSI_OSC */
 
-// Check if the byte after a ANSI_ESCAPE is a valid C1 code
-#define ANSI_IS_VALID_CODE(x) (((x) >= 0x40) && ((x) <= 0x5F))
+// Fe Escape Sequences
+#define ANSI_ST  '\\' /* String Terminator */
+#define ANSI_CSI '['  /* Control Sequence Introducer, terminated by a byte in range 0x40 through 0x7E */
+#define ANSI_OSC ']'  /* Operating System Command, terminated by ANSI_ST */
+#define ANSI_SOS 'X'  /* Start of String, terminated by ANSI_ST */
+#define ANSI_PM  '^'  /* Privacy Message, terminated by ANSI_ST */
+#define ANSI_APC '_'  /* Application Program Command, terminated by ANSI_ST */
+#define ANSI_DCS 'P'  /* Device Control String, terminated by ANSI_ST */
 
-// C1 codes
+// Fp Escape Sequences (Private Code)
+#define ANSI_DECSC '7' /* Save Current Cursor Position and Formatting Attributes */
+#define ANSI_DECRC '8' /* Restore Cursor Position and Formatting Attribute */
+
+// Control Sequence Introducer
+#define ANSI_CSI_CUU 'A' /* Cursor Up */
+#define ANSI_CSI_CUD 'B' /* Cursor Down */
+#define ANSI_CSI_CUF 'C' /* Cursor Forward */
+#define ANSI_CSI_CUB 'D' /* Cursor Back */
+#define ANSI_CSI_CNL 'E' /* Cursor Next Line */
+#define ANSI_CSI_CPL 'F' /* Cursor Previous Line */
+#define ANSI_CSI_CHA 'G' /* Cursor Horizontal Absolute */
+#define ANSI_CSI_CUP 'H' /* Cursor Position */
+#define ANSI_CSI_ED  'J' /* Erase in Display */
+#define ANSI_CSI_EL  'K' /* Erase in Line  */
+#define ANSI_CSI_SU  'S' /* Scroll Up */
+#define ANSI_CSI_SD  'T' /* Scroll Down */
+#define ANSI_CSI_HVP 'f' /* Horizontal Vertical Position */
+#define ANSI_CSI_SGR 'm' /* Select Graphic Rendition */
+#define ANSI_CSI_SCP 's' /* Save Current Cursor Position (Private Code) */
+#define ANSI_CSI_RCP 'u' /* Restore Saved Cursor Position (Private Code) */
+
+// Select Graphic Rendition
+#define ANSI_SGR_RESET             0   /* Turns off all attributes */
+#define ANSI_SGR_BOLD              1   /* Intensifies the color */
+#define ANSI_SGR_BOLD_RESET        22  /* De-intensifies the color */
+#define ANSI_SGR_INVERT            7   /* Swaps background and foreground colors */
+#define ANSI_SGR_INVERT_RESET      27  /* Un-swaps background and foreground colors */
+
+#define ANSI_SGR_FG_COLOR_BEGIN    30  /* First foreground color code */
+#define ANSI_SGR_FG_COLOR_END      37  /* Last foreground color code */
+//#define ANSI_SGR_FG_COLOR_EXTENDED 38  /* Marks the start of extended foreground color code */
+#define ANSI_SGR_FG_COLOR_RESET    39  /* Reset foreground color to the default value */
+//#define ANSI_SGR_FG_BOLD_BEGIN     90  /* Marks the start of intensified foreground color code */
+
+#define ANSI_SGR_BG_COLOR_BEGIN    40  /* First background color code */
+#define ANSI_SGR_BG_COLOR_END      47  /* Last background color code */
+//#define ANSI_SGR_BG_COLOR_EXTENDED 48  /* Marks the start of extended background color code */
+#define ANSI_SGR_BG_COLOR_RESET    49  /* Reset background color to the default value */
+//#define ANSI_SGR_BG_BOLD_BEGIN     100 /* Marks the start of intensified background color code */
+//#define ANSI_SGR_COLOR_PALLET      2   /* follows the _EXTENDED colors, marks the start of pallet color */
+//#define ANSI_SGR_COLOR_RGB         5   /* follows the _EXTENDED colors, marks the start of RGB color */
+
+// Helpers
+#define ANSI_CSI_FINAL(byte) (((byte) >= 0x40) && ((byte) <= 0x7E))

--- a/src/kernel/ansi.h
+++ b/src/kernel/ansi.h
@@ -47,20 +47,26 @@
 #define ANSI_SGR_BOLD_RESET        22  /* De-intensifies the color */
 #define ANSI_SGR_INVERT            7   /* Swaps background and foreground colors */
 #define ANSI_SGR_INVERT_RESET      27  /* Un-swaps background and foreground colors */
-
 #define ANSI_SGR_FG_COLOR_BEGIN    30  /* First foreground color code */
 #define ANSI_SGR_FG_COLOR_END      37  /* Last foreground color code */
 //#define ANSI_SGR_FG_COLOR_EXTENDED 38  /* Marks the start of extended foreground color code */
 #define ANSI_SGR_FG_COLOR_RESET    39  /* Reset foreground color to the default value */
-//#define ANSI_SGR_FG_BOLD_BEGIN     90  /* Marks the start of intensified foreground color code */
-
+#define ANSI_SGR_FG_BOLD_BEGIN     90  /* Marks the start of intensified foreground color code */
+#define ANSI_SGR_FG_BOLD_END       97  /* Last intensified foreground color code */
 #define ANSI_SGR_BG_COLOR_BEGIN    40  /* First background color code */
 #define ANSI_SGR_BG_COLOR_END      47  /* Last background color code */
 //#define ANSI_SGR_BG_COLOR_EXTENDED 48  /* Marks the start of extended background color code */
 #define ANSI_SGR_BG_COLOR_RESET    49  /* Reset background color to the default value */
-//#define ANSI_SGR_BG_BOLD_BEGIN     100 /* Marks the start of intensified background color code */
-//#define ANSI_SGR_COLOR_PALLET      2   /* follows the _EXTENDED colors, marks the start of pallet color */
-//#define ANSI_SGR_COLOR_RGB         5   /* follows the _EXTENDED colors, marks the start of RGB color */
+#define ANSI_SGR_BG_BOLD_BEGIN     100 /* Marks the start of intensified background color code */
+#define ANSI_SGR_BG_BOLD_END       107 /* Last intensified background color code */
+//#define ANSI_SGR_COLOR_PALLET      2   /* follows the *_EXTENDED colors, marks the start of pallet color */
+//#define ANSI_SGR_COLOR_RGB         5   /* follows the *_EXTENDED colors, marks the start of RGB color */
+
+// Erase modes (ANSI_CSI_ED, ANSI_CSI_EL)
+#define ANSI_ERASE_AFTER  0 /* Clear from cursor to the end of object */
+#define ANSI_ERASE_BEFORE 1 /* Clear from start of object to the cursor */
+#define ANSI_ERASE_WHOLE  2 /* Clear whole object */
+#define ANSI_ERASE_RESET  3 /* Clear whole object, and clear buffers (if applicable) */
 
 // Helpers
 #define ANSI_CSI_FINAL(byte) (((byte) >= 0x40) && ((byte) <= 0x7E))

--- a/src/kernel/config.h
+++ b/src/kernel/config.h
@@ -13,6 +13,6 @@
 
 /**
  * @brief The spacing between tab-stops, that is,
- *        the equivalent in spaces of the tab character
+ *        the equivalent in spaces of the tab character.
  */
 #define CONSOLE_TAB_DISTANCE 4

--- a/src/kernel/config.h
+++ b/src/kernel/config.h
@@ -16,3 +16,9 @@
  *        the equivalent in spaces of the tab character.
  */
 #define CONSOLE_TAB_DISTANCE 4
+
+/**
+ * @brief The maximum length of a number, in digits, as
+ *        as printed by kprintf() (for any base)
+ */
+#define KPRINTF_MAX_DIGITS 64

--- a/src/kernel/config.h
+++ b/src/kernel/config.h
@@ -1,0 +1,18 @@
+
+/**
+ * @brief The maximum length of any ANSI control sequence,
+ *        if a sequence that is longer is send to the output it will be ignored.
+ */
+#define CONSOLE_MAX_ANSI_SEQUENCE 64
+
+/**
+ * @brief The default attribute for screen buffer
+ *        that is used when ANSI attributes are reset.
+ */
+#define CONSOLE_DEFAULT_ATTRIBUTE 0b00000111
+
+/**
+ * @brief The spacing between tab-stops, that is,
+ *        the equivalent in spaces of the tab character
+ */
+#define CONSOLE_TAB_DISTANCE 4

--- a/src/kernel/console.c
+++ b/src/kernel/console.c
@@ -1,17 +1,409 @@
 #include "console.h"
 #include "memory.h"
 #include "ansi.h"
+#include "math.h"
 
 /* private */
 
-#define ATTR_DEFAULT 0b00000111;
+#define CONSOLE_MAX_ANSI_SEQUENCE 64
+#define CONSOLE_DEFAULT_ATTRIBUTE 0b00000111
+#define CONSOLE_TAB_DISTANCE 4
 
+void (*output_lexer) (char);
+
+static char sequence[CONSOLE_MAX_ANSI_SEQUENCE] = {0};
+static int length;
+
+// attribute background
+#define AB_I 0b10000000
+#define AB_R 0b01000000
+#define AB_G 0b00100000
+#define AB_B 0b00010000
+#define AB_C 0b01110000
+
+// attribute foreground
+#define AF_I 0b00001000
+#define AF_R 0b00000100
+#define AF_G 0b00000010
+#define AF_B 0b00000001
+#define AF_C 0b00000111
+
+static bool invert;
 static uint8_t attribute;
 static int width, height;
-static int x, y;
+static int x, y, sx, sy;
+
+int next_tab_stop() {
+    return (x / CONSOLE_TAB_DISTANCE) * CONSOLE_TAB_DISTANCE + ((x % CONSOLE_TAB_DISTANCE) ? CONSOLE_TAB_DISTANCE : 0);
+}
+
+static uint8_t ansi_to_rgb_bits(int index) {
+	int color = index & 7;
+	return (color & 0b010) | ((color & 0b001) << 2) | ((color & 0b100) >> 2);
+}
+
+static uint8_t con_attr() {
+	if (!invert) {
+		return attribute;
+	}
+
+	// inverted mode
+	uint8_t top = (0x0F & attribute) << 4;
+	return (top | (attribute >> 4)) & 0xFF;
+}
 
 static uint8_t* con_at(int x, int y) {
 	return (uint8_t*) &((uint16_t*) 0xB8000)[x + y * width];
+}
+
+static char con_next_char(int* head, int last) {
+	if (*head > last) {
+		return 0;
+	}
+
+	return sequence[(*head) ++];
+}
+
+static int con_next_int(int* head, int last, int fallback) {
+
+	bool first = true;
+	int accumulator = 0;
+
+	while (true) {
+		char next = con_next_char(head, last);
+
+		if ((next >= '0') && (next <= '9')) {
+			accumulator = accumulator * 10 + (next - '0');
+		} else {
+			(*head) --; // unput non-digit
+			return first ? fallback : accumulator;
+		}
+
+		first = false;
+	}
+
+	// unreachable
+	return -1;
+
+}
+
+static void con_srg_apply(int code) {
+	if (code == ANSI_SGR_RESET) {
+		attribute = CONSOLE_DEFAULT_ATTRIBUTE;
+		return;
+	}
+
+	if (code == ANSI_SGR_BOLD) {
+		attribute |= AF_I;
+		return;
+	}
+
+	if (code == ANSI_SGR_BOLD_RESET) {
+		attribute &= ~AF_I;
+		return;
+	}
+
+	if (code == ANSI_SGR_INVERT) {
+		invert = true;
+		return;
+	}
+
+	if (code == ANSI_SGR_INVERT_RESET) {
+		invert = false;
+		return;
+	}
+
+	if (code >= ANSI_SGR_FG_COLOR_BEGIN && code <= ANSI_SGR_FG_COLOR_END) {
+		int color = ansi_to_rgb_bits(code - ANSI_SGR_FG_COLOR_BEGIN); // last 3 bits
+		attribute = (attribute & ~AF_C) | color;
+	}
+
+	if (code >= ANSI_SGR_BG_COLOR_BEGIN && code <= ANSI_SGR_BG_COLOR_END) {
+		int color = ansi_to_rgb_bits(code - ANSI_SGR_BG_COLOR_BEGIN); // last 3 bits
+		attribute = (attribute & ~AB_C) | (color << 4); // move into place
+	}
+
+	if (code == ANSI_SGR_FG_COLOR_RESET) {
+		attribute = (attribute & ~AF_C) | (CONSOLE_DEFAULT_ATTRIBUTE & AF_C);
+	}
+
+	if (code == ANSI_SGR_BG_COLOR_RESET) {
+		attribute = (attribute & ~AB_C);
+	}
+
+}
+
+static void con_sgr_execute(int* head, int last) {
+
+	bool first = true;
+
+	// read an apply args until we run out
+	while (*head < last) {
+		int arg = con_next_int(head, last, -1);
+		con_next_char(head, last); // skip ';' or 'm'
+
+		if (arg == -1) {
+			break;
+		}
+
+		con_srg_apply(arg);
+		first = false;
+	}
+
+	// empty code ESC[m should be treated as ESC[0m
+	if (first) {
+		con_srg_apply(0);
+	}
+
+}
+
+static void con_csi_execute(int* head, int last) {
+	char code = sequence[last];
+
+	// move cursor up
+	if (code == ANSI_CSI_CUU) {
+		int arg = con_next_int(head, last, 1);
+		y = max(y - arg, 0);
+		return;
+	}
+
+	// move cursor down
+	if (code == ANSI_CSI_CUD) {
+		int arg = con_next_int(head, last, 1);
+		y = min(y + arg, height - 1);
+		return;
+	}
+
+	// move cursor forward
+	if (code == ANSI_CSI_CUF) {
+		int arg = con_next_int(head, last, 1);
+		x = min(x + arg, width - 1);
+		return;
+	}
+
+	// move cursor backward
+	if (code == ANSI_CSI_CUB) {
+		int arg = con_next_int(head, last, 1);
+		x = max(x - arg, 0);
+		return;
+	}
+
+	// cursor next line
+	if (code == ANSI_CSI_CNL) {
+		int arg = con_next_int(head, last, 1);
+		x = 0;
+		y = min(y + arg, height - 1);
+		return;
+	}
+
+	// cursor previous line
+	if (code == ANSI_CSI_CNL) {
+		int arg = con_next_int(head, last, 1);
+		x = 0;
+		y = min(y + arg, height - 1);
+		return;
+	}
+
+	// cursor position
+	if (code == ANSI_CSI_CUP || code == ANSI_CSI_HVP) {
+		int n = con_next_int(head, last, 1) - 1;
+		con_next_char(head, last); // ';'
+		int m = con_next_int(head, last, 1) - 1;
+
+		x = clamp(n, 0, width - 1);
+		y = clamp(n, 0, height - 1);
+		return;
+	}
+
+	// erase in display
+	if (code == ANSI_CSI_ED) {
+		int n = con_next_int(head, last, 0);
+		// TODO
+		return;
+	}
+
+	// erase in line
+	if (code == ANSI_CSI_EL) {
+		int n = con_next_int(head, last, 0);
+		// TODO
+		return;
+	}
+
+	// shift screen up
+	if (code == ANSI_CSI_SU) {
+		int n = con_next_int(head, last, 1);
+		// TODO
+		con_scroll(-n);
+		return;
+	}
+
+	// shift screen down
+	if (code == ANSI_CSI_SD) {
+		int n = con_next_int(head, last, 1);
+		// TODO
+		con_scroll(+n);
+		return;
+	}
+
+	// save cursor position
+	if (code == ANSI_CSI_SCP) {
+		sx = x;
+		sy = y;
+		return;
+	}
+
+	// restore cursor position
+	if (code == ANSI_CSI_SCP) {
+		x = sx;
+		y = sy;
+		return;
+	}
+
+	// color control
+	if (code == ANSI_CSI_SGR) {
+		con_sgr_execute(head, last);
+	}
+}
+
+static void con_execute() {
+
+	int last = length - 1;
+	int head = 1;
+
+	// for now we mostly only handle those and ignore the rest
+	if (sequence[0] == ANSI_CSI) {
+		con_csi_execute(&head, last);
+	}
+
+}
+
+/* lexers */
+
+static void con_lexer_initial(char code);
+static void con_lexer_escape(char code);
+static void con_lexer_csi(char code);
+static void con_lexer_until_st(char code);
+
+static void con_lexer_initial(char code) {
+
+	if (code == ANSI_BACKSPACE) {
+		if (x > 0) x --;
+		return;
+	}
+
+	if (code == ANSI_CARRIAGE_RETURN) {
+		x = 0;
+		return;
+	}
+
+	if (code == ANSI_LINE_FEED) {
+		y ++;
+		x = 0;
+
+		if (y >= height) {
+			con_scroll(+1);
+		}
+		return;
+	}
+
+	if (code == ANSI_ESCAPE) {
+		output_lexer = con_lexer_escape;
+		return;
+	}
+
+	if (code == ANSI_ESC_CSI) {
+		length = 0;
+		memset(sequence, 0, CONSOLE_MAX_ANSI_SEQUENCE);
+		sequence[length ++] = ANSI_CSI;
+
+		output_lexer = con_lexer_csi;
+		return;
+	}
+
+	if (code == ANSI_ESC_DCS || code == ANSI_ESC_OCS) {
+		length = 0;
+		memset(sequence, 0, CONSOLE_MAX_ANSI_SEQUENCE);
+		sequence[length ++] = ANSI_CSI;
+
+		output_lexer = con_lexer_until_st;
+		return;
+	}
+
+	if (code == ANSI_TAB) {
+		x = next_tab_stop();
+		goto adjust;
+	}
+
+	uint8_t* glyph = con_at(x, y);
+
+	glyph[0] = code;
+	glyph[1] = con_attr();
+
+adjust:
+
+	x ++;
+
+	if (x >= width) {
+		x = 0;
+		y ++;
+	}
+
+	if (y >= height) {
+		con_scroll(+1);
+	}
+
+}
+
+static void con_lexer_escape(char code) {
+
+	length = 0;
+	memset(sequence, 0, CONSOLE_MAX_ANSI_SEQUENCE);
+	sequence[length ++] = code;
+
+	if (code == ANSI_CSI) {
+		output_lexer = con_lexer_csi;
+		return;
+	}
+
+	if (code == ANSI_OSC || code == ANSI_SOS || code == ANSI_PM || code == ANSI_APC || code == ANSI_DCS) {
+		output_lexer = con_lexer_until_st;
+		return;
+	}
+
+	// unknown code, go back to printing
+	output_lexer = con_lexer_initial;
+	return;
+
+}
+
+static void con_lexer_csi(char code) {
+	sequence[length ++] = code;
+
+	if (ANSI_CSI_FINAL(code)) {
+		con_execute();
+		output_lexer = con_lexer_initial;
+	}
+
+	// error! we run out of space for ANSI control sequence
+	// we possibly now could just ignore everything until ANSI_CSI_FINAL
+	if (length >= CONSOLE_MAX_ANSI_SEQUENCE) {
+		output_lexer = con_lexer_initial;
+	}
+}
+
+static void con_lexer_until_st(char code) {
+	sequence[length ++] = code;
+
+	if (code == ANSI_ST && length > 1 && sequence[length - 2] == ANSI_ESCAPE) {
+		con_execute();
+		output_lexer = con_lexer_initial;
+	}
+
+	// error! we run out of space for ANSI control sequence
+	// we possibly now could just ignore everything until ESC+ST
+	if (length >= CONSOLE_MAX_ANSI_SEQUENCE) {
+		output_lexer = con_lexer_initial;
+	}
 }
 
 /* public */
@@ -21,7 +413,12 @@ void con_init(int max_width, int max_height) {
 	height = max_height;
 	x = 0;
 	y = 0;
-	attribute = ATTR_DEFAULT;
+	attribute = CONSOLE_DEFAULT_ATTRIBUTE;
+	output_lexer = con_lexer_initial;
+	length = 0;
+	sx = 0;
+	sy = 0;
+	invert = false;
 }
 
 void con_scroll(int offset) {
@@ -51,47 +448,5 @@ void con_scroll(int offset) {
 }
 
 void con_write(char code) {
-
-	if (code == ANSI_BACKSPACE) {
-		if (x > 0) x --;
-		return;
-	}
-
-	if (code == ANSI_CARRIAGE_RETURN) {
-		x = 0;
-		return;
-	}
-
-	if (code == ANSI_LINE_FEED) {
-		y ++;
-		x = 0;
-
-		if (y >= height) {
-			con_scroll(+1);
-		}
-		return;
-	}
-
-	if (code == ANSI_TAB) {
-		x += (x % 5) ? 5 : 0;
-		goto adjust;
-	}
-
-	uint8_t* glyph = con_at(x, y);
-
-	glyph[0] = code;
-	glyph[1] = attribute;
-
-adjust:
-
-	x ++;
-
-	if (x >= width) {
-		x = 0;
-		y ++;
-	}
-
-	if (y >= height) {
-		con_scroll(+1);
-	}
+	output_lexer(code);
 }

--- a/src/kernel/console.c
+++ b/src/kernel/console.c
@@ -1,0 +1,97 @@
+#include "console.h"
+#include "memory.h"
+#include "ansi.h"
+
+/* private */
+
+#define ATTR_DEFAULT 0b00000111;
+
+static uint8_t attribute;
+static int width, height;
+static int x, y;
+
+static uint8_t* con_at(int x, int y) {
+	return (uint8_t*) &((uint16_t*) 0xB8000)[x + y * width];
+}
+
+/* public */
+
+void con_init(int max_width, int max_height) {
+	width = max_width;
+	height = max_height;
+	x = 0;
+	y = 0;
+	attribute = ATTR_DEFAULT;
+}
+
+void con_scroll(int offset) {
+	long row = width * sizeof(uint16_t);
+	long last = height - 1;
+
+	if (offset == -1) {
+		memmove(con_at(0, 1), con_at(0, 0), last * row);
+		memset(con_at(0, 0), 0, row);
+
+		y ++;
+		if (y > last) y = last;
+
+		return;
+	}
+
+	if (offset == 1) {
+		memmove(con_at(0, 0), con_at(0, 1), last * row);
+		memset(con_at(0, last), 0, row);
+
+		y --;
+		if (y < 0) y = 0;
+
+		return;
+	}
+
+}
+
+void con_write(char code) {
+
+	if (code == ANSI_BACKSPACE) {
+		if (x > 0) x --;
+		return;
+	}
+
+	if (code == ANSI_CARRIAGE_RETURN) {
+		x = 0;
+		return;
+	}
+
+	if (code == ANSI_LINE_FEED) {
+		y ++;
+		x = 0;
+
+		if (y >= height) {
+			con_scroll(+1);
+		}
+		return;
+	}
+
+	if (code == ANSI_TAB) {
+		x += (x % 5) ? 5 : 0;
+		goto adjust;
+	}
+
+	uint8_t* glyph = con_at(x, y);
+
+	glyph[0] = code;
+	glyph[1] = attribute;
+
+adjust:
+
+	x ++;
+
+	if (x >= width) {
+		x = 0;
+		y ++;
+	}
+
+	if (y >= height) {
+		con_scroll(+1);
+	}
+}

--- a/src/kernel/console.h
+++ b/src/kernel/console.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "types.h"
+
+/**
+ * @brief Initializes the console subsystem, this needs to be called before the kernel
+ *        can print anything to the console. Sets the resultion of the screen.
+ *
+ * @param[in] max_width  Screen columns
+ * @param[in] max_height Screen rows
+ *
+ * @return None.
+ */
+void con_init(int max_width, int max_height);
+
+/**
+ * @brief Scrolls the screen one row up or down, once texts scrolls outside
+ *        the screen area it can not be scrolled back to.
+ *
+ * @param[in] offset Scroll direction, -1 to scroll down, +1 to scroll up
+ *
+ * @return None.
+ */
+void con_scroll(int offset);
+
+/**
+ * @brief Writes a single byte (char) to the system screen console,
+ *        this functions handles ANSI control codes. (See ansi.h).
+ *
+ * @param[in] The byte, or byte sequence part, to be written to the console.
+ *
+ * @return None.
+ */
+void con_write(char code);

--- a/src/kernel/console.h
+++ b/src/kernel/console.h
@@ -5,6 +5,7 @@
 /**
  * @brief Initializes the console subsystem, this needs to be called before the kernel
  *        can print anything to the console. Sets the resultion of the screen.
+ *        Cursor is placed at the first line one, and first culumn.
  *
  * @param[in] max_width  Screen columns
  * @param[in] max_height Screen rows
@@ -14,20 +15,25 @@
 void con_init(int max_width, int max_height);
 
 /**
- * @brief Scrolls the screen one row up or down, once texts scrolls outside
+ * @brief Scrolls the screen N row up or down, once texts scrolls outside
  *        the screen area it can not be scrolled back to.
+ *        Cursor position is updated to move along with the content.
  *
- * @param[in] offset Scroll direction, -1 to scroll down, +1 to scroll up
+ * @param[in] offset Scroll direction and line count, use to negative values scroll down, and positive to scroll up
  *
  * @return None.
  */
 void con_scroll(int offset);
 
 /**
- * @brief Scrolls the screen one row up or down, once texts scrolls outside
- *        the screen area it can not be scrolled back to.
+ * @brief Erases the screen content starting at (x1, y1) until (x2, y2),
+ *        note that this method dosn't erase a rectangle but a selection.
+ *        Cursor position is not updated.
  *
- * @param[in] offset Scroll direction, -1 to scroll down, +1 to scroll up
+ * @param[in] x1 The start row.
+ * @param[in] y1 The start column.
+ * @param[in] x2 The end row.
+ * @param[in] y2 The end column.
  *
  * @return None.
  */
@@ -36,6 +42,7 @@ void con_erase(int x1, int y1, int x2, int y2);
 /**
  * @brief Writes a single byte (char) to the system screen console,
  *        this functions handles ANSI control codes. (See ansi.h).
+ *        Cursor position is updated to reflect the written commands.
  *
  * @param[in] The byte, or byte sequence part, to be written to the console.
  *

--- a/src/kernel/console.h
+++ b/src/kernel/console.h
@@ -24,6 +24,16 @@ void con_init(int max_width, int max_height);
 void con_scroll(int offset);
 
 /**
+ * @brief Scrolls the screen one row up or down, once texts scrolls outside
+ *        the screen area it can not be scrolled back to.
+ *
+ * @param[in] offset Scroll direction, -1 to scroll down, +1 to scroll up
+ *
+ * @return None.
+ */
+void con_erase(int x1, int y1, int x2, int y2);
+
+/**
  * @brief Writes a single byte (char) to the system screen console,
  *        this functions handles ANSI control codes. (See ansi.h).
  *

--- a/src/kernel/entry.c
+++ b/src/kernel/entry.c
@@ -1,108 +1,14 @@
 
 #include "types.h"
 #include "console.h"
-#include "ansi.h"
+#include "print.h"
 
 extern char test();
 
 void start() {
 	con_init(80, 25);
 
-	for (int i = 0; i < 7; i ++) {
-		con_write('0');
-		con_write('1');
-		con_write('2');
-		con_write('3');
-	}
-
-	con_write(ANSI_LINE_FEED);
-
-	con_write('1');
-	con_write('2');
-	con_write('3');
-	con_write(ANSI_CARRIAGE_RETURN);
-	con_write('+');
-
-	con_write(ANSI_ESCAPE);
-	con_write(ANSI_CSI);
-	con_write('9');
-	con_write('4');
-	con_write(';');
-	con_write('1');
-	con_write('0');
-	con_write('1');
-	con_write(ANSI_CSI_SGR);
-
-	con_write(ANSI_TAB);
-	con_write('4');
-	con_write('5');
-
-	con_write(ANSI_ESCAPE);
-	con_write(ANSI_CSI);
-	con_write('7');
-	con_write(ANSI_CSI_SGR);
-
-	con_write(ANSI_TAB);
-	con_write('4');
-	con_write('5');
-
-	con_write(ANSI_ESCAPE);
-	con_write(ANSI_CSI);
-	con_write('2');
-	con_write('7');
-	con_write(ANSI_CSI_SGR);
-
-	con_write(ANSI_TAB);
-	con_write('4');
-	con_write('5');
-
-	con_write(ANSI_ESCAPE);
-	con_write(ANSI_CSI);
-	con_write('3');
-	con_write('9');
-	con_write(ANSI_CSI_SGR);
-
-	con_write(ANSI_TAB);
-	con_write('6');
-	con_write('7');
-
-	con_write(ANSI_ESCAPE);
-	con_write(ANSI_CSI);
-	con_write('4');
-	con_write('9');
-	con_write(ANSI_CSI_SGR);
-
-	con_write(ANSI_TAB);
-	con_write('8');
-	con_write('9');
-
-	con_write(ANSI_ESCAPE);
-	con_write(ANSI_CSI);
-	con_write(ANSI_CSI_SGR);
-
-	con_write(ANSI_TAB);
-	con_write('a');
-	con_write('b');
-
-	con_write(ANSI_ESCAPE);
-	con_write(ANSI_CSI);
-	con_write('9');
-	con_write(';');
-	con_write('1');
-	con_write(ANSI_CSI_HVP);
-
-	con_write('X');
-
-
-	con_write(ANSI_ESCAPE);
-	con_write(ANSI_CSI);
-	con_write('0');
-	con_write(ANSI_CSI_EL);
-
-//	con_write(ANSI_ESCAPE);
-//	con_write(ANSI_CSI);
-//	con_write('2');
-//	con_write(ANSI_CSI_SD);
+	kprintf("%% Hello \e[1;33m%s\e[m wo%cld, party like it's \e[1m0x%x\e[m again!", "sweet", 'r', 1920);
 
 	while (true) {
 		__asm("hlt");

--- a/src/kernel/entry.c
+++ b/src/kernel/entry.c
@@ -1,22 +1,41 @@
 
 #include "types.h"
-
-
-volatile bool truth = true;
+#include "console.h"
+#include "ansi.h"
 
 extern char test();
 
 void start() {
-	uint16_t volatile* screen = (uint16_t*) 0xB8000;
+	con_init(80, 25);
 
-	while (truth) {
-		for (int i = 0; i < 320 * 200; i ++) {
-			volatile uint8_t* chr = &screen[i];
+	con_write('B');
+	con_write('y');
+	con_write('e');
+	con_write('?');
+	con_write(ANSI_BACKSPACE);
+	con_write('!');
+	con_write(ANSI_LINE_FEED);
 
-			__asm ("nop");
+	con_write('1');
+	con_write('2');
+	con_write('3');
+	con_write(ANSI_CARRIAGE_RETURN);
+	con_write('+');
 
-			chr[0] = test();
-			chr[1] = 0b01001001;
-		}
+	con_write(ANSI_TAB);
+	con_write('4');
+	con_write('5');
+
+	con_write(ANSI_TAB);
+	con_write('6');
+	con_write('7');
+
+	con_write(ANSI_TAB);
+	con_write('8');
+	con_write('9');
+
+
+	while (true) {
+		__asm("hlt");
 	}
 }

--- a/src/kernel/entry.c
+++ b/src/kernel/entry.c
@@ -8,7 +8,7 @@ extern char test();
 void start() {
 	con_init(80, 25);
 
-	kprintf("%% Hello \e[1;33m%s\e[m wo%cld, party like it's \e[1m0x%x\e[m again!", "sweet", 'r', 1920);
+	kprintf("\e[2J%% Hello \e[1;33m%s\e[m wo%cld, party like it's \e[1m0x%x\e[m again!", "sweet", 'r', 1920);
 
 	while (true) {
 		__asm("hlt");

--- a/src/kernel/entry.c
+++ b/src/kernel/entry.c
@@ -8,12 +8,19 @@ extern char test();
 void start() {
 	con_init(80, 25);
 
-	con_write('B');
-	con_write('y');
-	con_write('e');
-	con_write('?');
-	con_write(ANSI_BACKSPACE);
-	con_write('!');
+	for (int i = 0; i < 7; i ++) {
+		con_write('0');
+		con_write('1');
+		con_write('2');
+		con_write('3');
+	}
+
+//	con_write('B');
+//	con_write('y');
+//	con_write('e');
+//	con_write('?');
+//	con_write(ANSI_BACKSPACE);
+//	con_write('!');
 	con_write(ANSI_LINE_FEED);
 
 	con_write('1');
@@ -22,17 +29,78 @@ void start() {
 	con_write(ANSI_CARRIAGE_RETURN);
 	con_write('+');
 
+	con_write(ANSI_ESCAPE);
+	con_write(ANSI_CSI);
+	con_write('3');
+	con_write('4');
+	con_write(';');
+	con_write('1');
+	con_write(';');
+	con_write('4');
+	con_write('1');
+	con_write(ANSI_CSI_SGR);
+
 	con_write(ANSI_TAB);
 	con_write('4');
 	con_write('5');
+
+	con_write(ANSI_ESCAPE);
+	con_write(ANSI_CSI);
+	con_write('7');
+	con_write(ANSI_CSI_SGR);
+
+	con_write(ANSI_TAB);
+	con_write('4');
+	con_write('5');
+
+	con_write(ANSI_ESCAPE);
+	con_write(ANSI_CSI);
+	con_write('2');
+	con_write('7');
+	con_write(ANSI_CSI_SGR);
+
+	con_write(ANSI_TAB);
+	con_write('4');
+	con_write('5');
+
+	con_write(ANSI_ESCAPE);
+	con_write(ANSI_CSI);
+	con_write('3');
+	con_write('9');
+	con_write(ANSI_CSI_SGR);
 
 	con_write(ANSI_TAB);
 	con_write('6');
 	con_write('7');
 
+	con_write(ANSI_ESCAPE);
+	con_write(ANSI_CSI);
+	con_write('4');
+	con_write('9');
+	con_write(ANSI_CSI_SGR);
+
 	con_write(ANSI_TAB);
 	con_write('8');
 	con_write('9');
+
+	con_write(ANSI_ESCAPE);
+	con_write(ANSI_CSI);
+	con_write(ANSI_CSI_SGR);
+
+	con_write(ANSI_TAB);
+	con_write('a');
+	con_write('b');
+
+	con_write(ANSI_ESCAPE);
+	con_write(ANSI_CSI);
+	con_write('1');
+	con_write('0');
+	con_write(';');
+	con_write('1');
+	con_write('0');
+	con_write(ANSI_CSI_HVP);
+
+	con_write('X');
 
 
 	while (true) {

--- a/src/kernel/entry.c
+++ b/src/kernel/entry.c
@@ -15,12 +15,6 @@ void start() {
 		con_write('3');
 	}
 
-//	con_write('B');
-//	con_write('y');
-//	con_write('e');
-//	con_write('?');
-//	con_write(ANSI_BACKSPACE);
-//	con_write('!');
 	con_write(ANSI_LINE_FEED);
 
 	con_write('1');
@@ -31,12 +25,11 @@ void start() {
 
 	con_write(ANSI_ESCAPE);
 	con_write(ANSI_CSI);
-	con_write('3');
+	con_write('9');
 	con_write('4');
 	con_write(';');
 	con_write('1');
-	con_write(';');
-	con_write('4');
+	con_write('0');
 	con_write('1');
 	con_write(ANSI_CSI_SGR);
 
@@ -93,15 +86,23 @@ void start() {
 
 	con_write(ANSI_ESCAPE);
 	con_write(ANSI_CSI);
-	con_write('1');
-	con_write('0');
+	con_write('9');
 	con_write(';');
 	con_write('1');
-	con_write('0');
 	con_write(ANSI_CSI_HVP);
 
 	con_write('X');
 
+
+	con_write(ANSI_ESCAPE);
+	con_write(ANSI_CSI);
+	con_write('0');
+	con_write(ANSI_CSI_EL);
+
+//	con_write(ANSI_ESCAPE);
+//	con_write(ANSI_CSI);
+//	con_write('2');
+//	con_write(ANSI_CSI_SD);
 
 	while (true) {
 		__asm("hlt");

--- a/src/kernel/math.c
+++ b/src/kernel/math.c
@@ -1,0 +1,30 @@
+
+#include "math.h"
+
+/* public */
+
+int max(int left, int right) {
+	return (left > right) ? left : right;
+}
+
+int min(int left, int right) {
+	return (left < right) ? left : right;
+}
+
+int clamp(int value, int low, int high) {
+	if (value < low) return low;
+	if (value > high) return high;
+
+	return value;
+}
+
+int sgn(int value) {
+	if (value < 0) return -1;
+	if (value > 0) return +1;
+
+	return 0;
+}
+
+int abs(int value) {
+	return (value < 0) ? (-value) : (+value);
+}

--- a/src/kernel/math.h
+++ b/src/kernel/math.h
@@ -1,0 +1,4 @@
+
+#define max(a, b) (((a) > (b)) ? (a) : (b))
+#define min(a, b) (((a) < (b)) ? (a) : (b))
+#define clamp(v, l, h) (((v) < (l)) ? (l) : (((v) > (h)) ? (h) : (v)))

--- a/src/kernel/math.h
+++ b/src/kernel/math.h
@@ -1,4 +1,52 @@
+#pragma once
 
-#define max(a, b) (((a) > (b)) ? (a) : (b))
-#define min(a, b) (((a) < (b)) ? (a) : (b))
-#define clamp(v, l, h) (((v) < (l)) ? (l) : (((v) > (h)) ? (h) : (v)))
+/**
+ * @brief Returns the larger of the two given values.
+ *
+ * @param[in]  left  First value.
+ * @param[in]  right Second value.
+ *
+ * @return Returns the larger value.
+ */
+int max(int left, int right);
+
+/**
+ * @brief Returns the smaller of the two given values.
+ *
+ * @param[in]  left  First value.
+ * @param[in]  right Second value.
+ *
+ * @return Returns the smaller value.
+ */
+int min(int left, int right);
+
+/**
+ * @brief Clamps the given value to the given range.
+ *
+ * @param[in]  value The value to clamp.
+ * @param[in]  low   The lower bound of the value.
+ * @param[in]  high  The upper bound of the value.
+ *
+ * @return Returns a integer in range [low, high].
+ */
+int clamp(int value, int low, int high);
+
+/**
+ * @brief Returns the sign of the number, or 0 if the number is 0,
+ *        such that `sgn(val) * abs(val) == val`
+ *
+ * @param[in] value The value to compute the sign of.
+ *
+ * @return Returns a integer from set {-1, 0, +1}.
+ */
+int sgn(int value);
+
+/**
+ * @brief Returns the absolute value of the give integer,
+ *        such that `abs(-10) == abs(10)`
+ *
+ * @param[in] value The value to compute the absolute value of.
+ *
+ * @return Returns a non-negative integer.
+ */
+int abs(int value);

--- a/src/kernel/memory.c
+++ b/src/kernel/memory.c
@@ -1,0 +1,37 @@
+#include "memory.h"
+
+void* memcpy(void* dst, const void* src, long bytes) {
+	if (src == dst) {
+		return dst;
+	}
+
+	for (long i = 0; i < bytes; i ++) {
+		((uint8_t*) dst)[i] = ((uint8_t*) src)[i];
+	}
+
+	return dst;
+}
+
+void* memmove(void* dst, const void* src, long bytes) {
+	if (src == dst) {
+		return dst;
+	}
+
+	if (src > dst) {
+		return memcpy(dst, src, bytes);
+	}
+
+	for (long i = bytes - 1; i >= 0; i --) {
+		((uint8_t*) dst)[i] = ((uint8_t*) src)[i];
+	}
+
+	return dst;
+}
+
+void* memset(void* dst, uint8_t value, long bytes) {
+	for (long i = 0; i < bytes; i ++) {
+		((uint8_t*) dst)[i] = value;
+	}
+
+	return dst;
+}

--- a/src/kernel/memory.c
+++ b/src/kernel/memory.c
@@ -1,7 +1,7 @@
 #include "memory.h"
 
 void* memcpy(void* dst, const void* src, long bytes) {
-	if (src == dst) {
+	if ((src == dst) || (bytes == 0)) {
 		return dst;
 	}
 
@@ -13,7 +13,7 @@ void* memcpy(void* dst, const void* src, long bytes) {
 }
 
 void* memmove(void* dst, const void* src, long bytes) {
-	if (src == dst) {
+	if ((src == dst) || (bytes == 0)) {
 		return dst;
 	}
 
@@ -34,4 +34,14 @@ void* memset(void* dst, uint8_t value, long bytes) {
 	}
 
 	return dst;
+}
+
+int strlen(const char* cstr) {
+	int length = 0;
+
+	while(cstr[length] != '\0') {
+		length ++;
+	}
+
+	return length;
 }

--- a/src/kernel/memory.h
+++ b/src/kernel/memory.h
@@ -12,7 +12,7 @@
  *
  * @return Returns a pointer to the buffer that was written to.
  */
-void* memcpy (void* dst, const void* src, long bytes);
+void* memcpy(void* dst, const void* src, long bytes);
 
 /**
  * @brief Copies `bytes` bytes from `src` to `dst`. The memory blocks can overlap,
@@ -24,7 +24,7 @@ void* memcpy (void* dst, const void* src, long bytes);
  *
  * @return Returns a pointer to the buffer that was written to.
  */
-void* memmove (void* dst, const void* src, long bytes);
+void* memmove(void* dst, const void* src, long bytes);
 
 /**
  * @brief Sets the first `bytes` bytes of the block of memory
@@ -36,4 +36,15 @@ void* memmove (void* dst, const void* src, long bytes);
  *
  * @return Returns a pointer to the buffer that was written to.
  */
-void* memset (void* dst, uint8_t value, long bytes);
+void* memset(void* dst, uint8_t value, long bytes);
+
+/**
+ * @brief Returns the length of the given null-terminated byte string,
+ *        that is, the number of characters in a character array whose first element is
+ *        pointed to by `cstr` up to and not including the first null character.
+ *
+ * @param[in] cstr Pointer to the null-terminated byte string.
+ *
+ * @return Returns The length of the null-terminated byte string.
+ */
+int strlen(const char* cstr);

--- a/src/kernel/memory.h
+++ b/src/kernel/memory.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "types.h"
+
+/**
+ * @brief Copies `bytes` bytes from `src` to `dst`. The memory blocks must not overlap,
+ *        if they do, consider using `memmove()`.
+ *
+ * @param[out] dst   Pointer to the destination array where the content is to be copied.
+ * @param[in]  src   Pointer to the source of data to be copied.
+ * @param[in]  bytes Number of bytes to copy.
+ *
+ * @return Returns a pointer to the buffer that was written to.
+ */
+void* memcpy (void* dst, const void* src, long bytes);
+
+/**
+ * @brief Copies `bytes` bytes from `src` to `dst`. The memory blocks can overlap,
+ *        if they do not, consider using `memcpy()`.
+ *
+ * @param[out] dst   Pointer to the destination array where the content is to be copied.
+ * @param[in]  src   Pointer to the source of data to be copied.
+ * @param[in]  bytes Number of bytes to copy.
+ *
+ * @return Returns a pointer to the buffer that was written to.
+ */
+void* memmove (void* dst, const void* src, long bytes);
+
+/**
+ * @brief Sets the first `bytes` bytes of the block of memory
+ *        pointed by `dst` to the specified value.
+ *
+ * @param[out] dst   Pointer to the block of memory to fill.
+ * @param[in]  value Value that is to be written to each byte in destination.
+ * @param[in]  bytes Number of bytes to be set to the value.
+ *
+ * @return Returns a pointer to the buffer that was written to.
+ */
+void* memset (void* dst, uint8_t value, long bytes);

--- a/src/kernel/print.c
+++ b/src/kernel/print.c
@@ -1,0 +1,2 @@
+#include "print.h"
+#include "console.h"

--- a/src/kernel/print.c
+++ b/src/kernel/print.c
@@ -1,6 +1,7 @@
 #include "print.h"
 #include "console.h"
 #include "types.h"
+#include "config.h"
 
 /* private */
 
@@ -19,8 +20,9 @@ void kprint_string(const char* string) {
 void kprint_integer(long integer, int base) {
 	const char digits[] = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
-	char buffer[64] = {0};
-	int i = 30;
+	char buffer[KPRINTF_MAX_DIGITS] = {0};
+	int i = KPRINTF_MAX_DIGITS - 2;
+	//buffer[i] = 0;
 
 	// early return
 	if (integer == 0) {

--- a/src/kernel/print.c
+++ b/src/kernel/print.c
@@ -1,2 +1,110 @@
 #include "print.h"
 #include "console.h"
+#include "types.h"
+
+/* private */
+
+void kprint_string(const char* string) {
+	for (int i = 0; true; i ++) {
+		char chr = string[i];
+
+		if (chr == '\0') {
+			break;
+		}
+
+		con_write(chr);
+	}
+}
+
+void kprint_integer(long integer, int base) {
+	const char digits[] = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+	char buffer[64] = {0};
+	int i = 30;
+
+	// early return
+	if (integer == 0) {
+		con_write('0');
+		return;
+	}
+
+	if (integer < 0) {
+		con_write('-');
+		integer = -integer;
+	}
+
+	while (integer && i) {
+		long rem = integer % base;
+		buffer[i--] = digits[rem];
+		integer /= base;
+	}
+
+	kprint_string(&buffer[i + 1]);
+}
+
+/* public */
+
+void kprintf(const char* pattern, ...) {
+	va_list args;
+	va_start(args, pattern);
+
+	bool escape = false;
+
+	for (int i = 0; true; i ++) {
+		char chr = pattern[i];
+
+		if (chr == '\0') {
+			break;
+		}
+
+		if (escape) {
+			escape = false;
+
+			if (chr == '%') {
+				con_write(chr);
+				continue;
+			}
+
+			if (chr == 's') {
+				kprint_string(va_arg(args, const char*));
+				continue;
+			}
+
+			if (chr == 'b') {
+				kprint_integer(va_arg(args, int), 2);
+				continue;
+			}
+
+			if (chr == 'o') {
+				kprint_integer(va_arg(args, int), 8);
+				continue;
+			}
+
+			if (chr == 'd' || chr == 'i') {
+				kprint_integer(va_arg(args, int), 10);
+				continue;
+			}
+
+			if (chr == 'x') {
+				kprint_integer(va_arg(args, int), 16);
+				continue;
+			}
+
+			if (chr == 'c') {
+				con_write(va_arg(args, int) & 0xFF);
+				continue;
+			}
+
+			continue;
+		}
+
+		if (chr == '%') {
+			escape = true;
+			continue;
+		}
+
+		con_write(chr);
+	}
+
+	va_end(args);
+}

--- a/src/kernel/print.h
+++ b/src/kernel/print.h
@@ -1,0 +1,1 @@
+#pragma once

--- a/src/kernel/print.h
+++ b/src/kernel/print.h
@@ -1,1 +1,27 @@
 #pragma once
+
+/**
+ * @brief Writes the C string pointed by `pattern` to the standard output
+ *        If `pattern` includes format specifiers (subsequences beginning with %),
+ *        the additional arguments following the `pattern` are formatted and inserted in
+ *        the resulting string replacing their respective specifiers.
+ *
+ *        Specifier | Output                     | Example
+ *        --------- | -------------------------- | -------
+ *        %d %i     | Signed decimal integer     | 420
+ *        %o        | Signed octal decimal       | 644
+ *        %x        | Signed hexadecimal integer | 1A4
+ *        %b        | Signed binary integer      | 110100100
+ *        %c        | Single character           | a
+ *        %s        | Null-terminated string     | Hello!
+ *        %%        | A literal '%' character    | %
+ *
+ *        If  a specific specifiers sequence is not recoginez it will be
+ *        ignored and skipped, without producing any output.
+ *
+ * @param[in] pattern C string that contains the text to be written, with optional embedded format specifiers.
+ * @param[in] ...     Depending on the format string, the function may expect a sequence of additional arguments.
+ *
+ * @return Returns a pointer to the buffer that was written to.
+ */
+void kprintf(const char* pattern, ...);

--- a/src/kernel/types.h
+++ b/src/kernel/types.h
@@ -1,3 +1,4 @@
+#pragma GCC system_header
 
 typedef unsigned char bool;
 typedef unsigned char uint8_t;
@@ -7,3 +8,13 @@ typedef unsigned int size_t;
 
 #define true 1
 #define false 0
+
+// varargs
+#ifndef va_start
+typedef __builtin_va_list va_list;
+
+#	define va_start __builtin_va_start
+#	define va_end __builtin_va_end
+#	define va_copy __builtin_va_copy
+#	define va_arg __builtin_va_arg
+#endif

--- a/src/kernel/types.h
+++ b/src/kernel/types.h
@@ -3,6 +3,7 @@ typedef unsigned char bool;
 typedef unsigned char uint8_t;
 typedef unsigned short uint16_t;
 typedef unsigned int uint32_t;
+typedef unsigned int size_t;
 
 #define true 1
 #define false 0

--- a/src/link/kernel.ld
+++ b/src/link/kernel.ld
@@ -5,15 +5,17 @@ INPUT(build/kernel/entry.o)
 INPUT(build/kernel/kmalloc.o)
 INPUT(build/kernel/console.o)
 INPUT(build/kernel/memory.o)
+INPUT(build/kernel/math.o)
 
 SECTIONS {
 	. = 0x8000;
 
-	/* Copy code and data for second stage */
+	/* First output all the functions */
 	.text : SUBALIGN(0) {
 		*(.text)
 	}
 
+	/* And then all the data */
 	.data : SUBALIGN(4) {
 		*(.rodata*)
 		*(.data)

--- a/src/link/kernel.ld
+++ b/src/link/kernel.ld
@@ -3,6 +3,8 @@ ENTRY(start)
 /* Files that need to be linked together */
 INPUT(build/kernel/entry.o)
 INPUT(build/kernel/kmalloc.o)
+INPUT(build/kernel/console.o)
+INPUT(build/kernel/memory.o)
 
 SECTIONS {
 	. = 0x8000;

--- a/src/link/kernel.ld
+++ b/src/link/kernel.ld
@@ -1,12 +1,5 @@
 ENTRY(start)
 
-/* Files that need to be linked together */
-INPUT(build/kernel/entry.o)
-INPUT(build/kernel/kmalloc.o)
-INPUT(build/kernel/console.o)
-INPUT(build/kernel/memory.o)
-INPUT(build/kernel/math.o)
-
 SECTIONS {
 	. = 0x8000;
 


### PR DESCRIPTION
- Console functions (`con_init`, `con_scroll`, `con_erase`, `con_write`) with extensive [ANSI](https://en.wikipedia.org/wiki/ANSI_escape_code) support
- Helper math & memory functions (`min`, `max`, `clamp`, `sgn`, `abs`, `memcpy`, `memmove`, `memset`, `strlen`)
- Added va_list support using GCC compiler builtins (see `types.h`)
- Better makefile setup, new files now need to be defined in only one place - the `KERNEL_CC`/`KERNEL_AS` arrays
- Basic `kprintf` with support for `%d`, `%i`, `%s`, `%c`, `%x`, `%o`, `%%`, and non-standard `%b`